### PR TITLE
Added hotkeys to switch between editor and terminal panels

### DIFF
--- a/addons/gdterm/terminal.gd
+++ b/addons/gdterm/terminal.gd
@@ -63,6 +63,32 @@ var font_size_info = {
 	"hint_string" : "8,64,1"
 }
 
+enum INSTANCE_TYPE { MAIN, BOTTOM }
+var main_panel_switch_shortcut : Shortcut = Shortcut.new()
+var bottom_panel_toggle_shortcut : Shortcut = Shortcut.new()
+var bottom_panel_focus_shortcut : Shortcut = Shortcut.new()
+
+var main_panel_switch_info  = {
+	"name": "gdterm/main_panel_switch",
+	"type": TYPE_OBJECT,
+	"hint": PROPERTY_HINT_RESOURCE_TYPE,
+	"hint_string": "InputEventKey"
+}
+
+var bottom_panel_toggle_info  = {
+	"name": "gdterm/bottom_panel_toggle",
+	"type": TYPE_OBJECT,
+	"hint": PROPERTY_HINT_RESOURCE_TYPE,
+	"hint_string": "InputEventKey"
+}
+
+var bottom_panel_focus_info  = {
+	"name": "gdterm/bottom_panel_focus",
+	"type": TYPE_OBJECT,
+	"hint": PROPERTY_HINT_RESOURCE_TYPE,
+	"hint_string": "InputEventKey"
+}
+
 func _on_settings_changed():
 	var settings = EditorInterface.get_editor_settings()
 	
@@ -90,11 +116,33 @@ func _on_settings_changed():
 	var font_size : int = 14
 	if settings.has_setting("gdterm/font_size"):
 		font_size = settings.get_setting("gdterm/font_size")
+
+	var main_panel_switch : InputEventKey = InputEventKey.new()
+	main_panel_switch.ctrl_pressed = true
+	main_panel_switch.keycode = KEY_F6
+	if settings.has_setting("gdterm/main_panel_switch"):
+		main_panel_switch = settings.get_setting("gdterm/main_panel_switch")
+	
+	var bottom_panel_toggle : InputEventKey = InputEventKey.new()
+	bottom_panel_toggle.alt_pressed = true
+	bottom_panel_toggle.keycode = KEY_T
+	if settings.has_setting("gdterm/bottom_panel_toggle"):
+		bottom_panel_toggle = settings.get_setting("gdterm/bottom_panel_toggle")
+
+	var bottom_panel_focus : InputEventKey = InputEventKey.new()
+	bottom_panel_focus.ctrl_pressed = true
+	bottom_panel_focus.keycode = KEY_T
+	if settings.has_setting("gdterm/bottom_panel_focus"):
+		bottom_panel_focus = settings.get_setting("gdterm/bottom_panel_focus")
+
 	_apply_theme(theme)
 	_apply_initial_cmds(initial_cmds)
 	_apply_term_alt_meta_setting(send_alt_meta_as_esc)
 	_apply_font_setting(font, font_size)
 	_apply_layout(layout)
+	_apply_main_panel_switch(main_panel_switch)
+	_apply_bottom_panel_toggle(bottom_panel_toggle)
+	_apply_bottom_panel_focus(bottom_panel_focus)
 
 func _apply_theme(theme):
 	if current_theme != theme:
@@ -133,7 +181,7 @@ func _apply_theme(theme):
 			bottom_panel_instance.set_theme(active_theme)
 			bottom_panel_instance.theme_changed()
 		current_theme = theme
-	
+
 func _apply_layout(layout):
 	if current_layout != layout:
 		if layout == LAYOUT_MAIN or layout == LAYOUT_BOTH:
@@ -157,6 +205,11 @@ func _apply_layout(layout):
 				main_panel_instance.get_main().set_active(true)
 				main_panel_instance.visible = show_main
 				EditorInterface.get_editor_main_screen().add_child(main_panel_instance)
+
+				main_panel_instance.get_main().set_instance_type(INSTANCE_TYPE.MAIN)
+				main_panel_instance.get_main().set_main_panel_switch(main_panel_switch_shortcut, main_panel_instance)
+
+
 		if layout == LAYOUT_BOTTOM or layout == LAYOUT_BOTH:
 			if bottom_panel_instance == null:
 				bottom_panel_instance = BottomPanel.instantiate()
@@ -167,7 +220,17 @@ func _apply_layout(layout):
 					bottom_panel_instance.set_font_setting(active_font, active_font_size)
 					bottom_panel_instance.set_active(true)
 					bottom_panel_instance.theme_changed()
-				add_control_to_bottom_panel(bottom_panel_instance, "Terminal")
+				
+				var bottom_panel_button = add_control_to_bottom_panel(
+					bottom_panel_instance, 
+					"Terminal",
+					bottom_panel_toggle_shortcut
+					)
+
+				bottom_panel_instance.set_instance_type(INSTANCE_TYPE.BOTTOM)
+				bottom_panel_instance.set_bottom_panel_toggle(bottom_panel_button)
+				bottom_panel_instance.set_bottom_panel_focus(bottom_panel_focus_shortcut)
+
 		if layout == LAYOUT_MAIN:
 			if bottom_panel_instance != null:
 				remove_control_from_bottom_panel(bottom_panel_instance)
@@ -205,6 +268,15 @@ func _apply_font_setting(font : Font, font_size : int):
 			bottom_panel_instance.set_font_setting(font, font_size)
 		active_font = font
 		active_font_size = font_size
+
+func _apply_main_panel_switch(main_panel_switch : InputEventKey):
+	main_panel_switch_shortcut.events = [main_panel_switch]
+
+func _apply_bottom_panel_toggle(bottom_panel_toggle : InputEventKey):
+	bottom_panel_toggle_shortcut.events = [bottom_panel_toggle]
+
+func _apply_bottom_panel_focus(bottom_panel_focus : InputEventKey):
+	bottom_panel_focus_shortcut.events = [bottom_panel_focus]
 
 func _enter_tree() -> void:
 	var settings = EditorInterface.get_editor_settings()
@@ -250,6 +322,33 @@ func _enter_tree() -> void:
 	else:
 		settings.set_setting("gdterm/send_alt_meta_as_esc", alt_meta_setting)
 	_apply_term_alt_meta_setting(alt_meta_setting)
+	
+	var main_panel_switch : InputEventKey = InputEventKey.new()
+	main_panel_switch.ctrl_pressed = true
+	main_panel_switch.keycode = KEY_F6
+	if settings.has_setting("gdterm/main_panel_switch"):
+		main_panel_switch = settings.get_setting("gdterm/main_panel_switch")
+	else:
+		settings.set_setting("gdterm/main_panel_switch", main_panel_switch)
+	_apply_main_panel_switch(main_panel_switch)
+
+	var bottom_panel_toggle : InputEventKey = InputEventKey.new()
+	bottom_panel_toggle.alt_pressed = true
+	bottom_panel_toggle.keycode = KEY_T
+	if settings.has_setting("gdterm/bottom_panel_toggle"):
+		bottom_panel_toggle = settings.get_setting("gdterm/bottom_panel_toggle")
+	else:
+		settings.set_setting("gdterm/bottom_panel_toggle", bottom_panel_toggle)
+	_apply_bottom_panel_toggle(bottom_panel_toggle)
+
+	var bottom_panel_focus : InputEventKey = InputEventKey.new()
+	bottom_panel_focus.ctrl_pressed = true
+	bottom_panel_focus.keycode = KEY_T
+	if settings.has_setting("gdterm/bottom_panel_focus"):
+		bottom_panel_focus = settings.get_setting("gdterm/bottom_panel_focus")
+	else:
+		settings.set_setting("gdterm/bottom_panel_focus", bottom_panel_focus)
+	_apply_bottom_panel_focus(bottom_panel_focus)
 
 	# Make sure shows as enum
 	settings.add_property_info(theme_property_info)
@@ -258,6 +357,8 @@ func _enter_tree() -> void:
 	settings.add_property_info(send_alt_meta_as_esc_info)
 	settings.add_property_info(font_info)
 	settings.add_property_info(font_size_info)
+	settings.add_property_info(bottom_panel_toggle_info)
+	settings.add_property_info(bottom_panel_focus_info)
 	settings.settings_changed.connect(_on_settings_changed)
 	
 	# All the initial settings have been made, so make it active
@@ -304,3 +405,4 @@ func _get_plugin_name():
 
 func _get_plugin_icon():
 	return EditorInterface.get_editor_theme().get_icon("Node", "EditorIcons")
+

--- a/addons/gdterm/terminal/main.gd
+++ b/addons/gdterm/terminal/main.gd
@@ -1,6 +1,9 @@
 @tool
 extends MarginContainer
 
+enum INSTANCE_TYPE {MAIN, BOTTOM}
+var instance_type : INSTANCE_TYPE
+
 func set_active(flag : bool):
 	$term_container.set_active(flag)
 
@@ -18,3 +21,53 @@ func set_font_setting(font, font_size):
 
 func _on_theme_changed():
 	theme_changed()
+
+func set_instance_type(type : INSTANCE_TYPE):
+	instance_type = type
+
+func set_bottom_panel_toggle(button: Button):
+	button.pressed.connect(focus_bottom_panel_terminal)
+
+func set_main_panel_switch(shortcut: Shortcut, control: Control):
+	main_panel_control = control
+	print("super init")
+	add_offscreen_button_shortcut(shortcut, switch_main_panel_terminal, main_panel_control.get_parent())
+
+func set_bottom_panel_focus(shortcut: Shortcut):
+	add_offscreen_button_shortcut(shortcut, focus_bottom_panel_terminal, self)
+
+var main_panel_control : Control
+func switch_main_panel_terminal():
+	if(instance_type == INSTANCE_TYPE.MAIN):
+		EditorInterface.set_main_screen_editor("Terminal")
+		$term_container/term/GDTerm.grab_focus()
+
+func focus_bottom_panel_terminal():
+	if(instance_type == INSTANCE_TYPE.BOTTOM):
+		$term_container/term/GDTerm.grab_focus()
+
+func add_offscreen_button_shortcut(
+	shortcut : Shortcut, 
+	press_handler : Callable,
+	parent_control : Control
+	):
+	var offscreen_control_parent : Control = Control.new()
+	offscreen_control_parent.size_flags_horizontal = Control.SIZE_SHRINK_BEGIN
+	offscreen_control_parent.size_flags_vertical = Control.SIZE_SHRINK_BEGIN
+	offscreen_control_parent.mouse_filter = Control.MOUSE_FILTER_PASS
+	offscreen_control_parent.clip_contents = true
+	
+	var offscreen_control : Control = Control.new()
+	offscreen_control.mouse_filter = Control.MOUSE_FILTER_PASS
+	offscreen_control.position.y = -100
+	
+	var offscreen_button = Button.new()
+	offscreen_button.shortcut = shortcut
+	offscreen_button.focus_mode = Control.FOCUS_NONE
+	offscreen_button.pressed.connect(press_handler)
+
+	offscreen_control_parent.add_child(offscreen_control)
+	offscreen_control.add_child(offscreen_button)
+
+	parent_control.add_child(offscreen_control_parent)
+#	$Offsceen/Control.add_child(offscreen_button)

--- a/addons/gdterm/terminal/main.gd
+++ b/addons/gdterm/terminal/main.gd
@@ -70,4 +70,3 @@ func add_offscreen_button_shortcut(
 	offscreen_control.add_child(offscreen_button)
 
 	parent_control.add_child(offscreen_control_parent)
-#	$Offsceen/Control.add_child(offscreen_button)


### PR DESCRIPTION
**1. Added a bottom panel toggle hotkey**
Default hotkey is Alt+T. Implementation is done using one of the built-in EditorPlugin methods for bottom panel. Terminal will be focused automatically when toggling on the panel.

**2. Added a bottom panel focus hotkey**
Originally, coming back to the terminal after leaving it to use some other editor window requires a mouse click which is awkward for a keyboard focused workflow. Using this, one can be in any other part of the editor and get directly into the terminal, as long as the bottom panel is toggled on. 
<br>Default hotkey is Ctrl+T. Implementation is done using an offscreen Button added via code and hidden from view via clipping with a parent Control. Pressing the hotkey, triggers the Button as Buttons can be attached with a Shortcut. Reason for using this approach vs processing InputEvents is that if the user sets the hotkey with Physical Key, it may not trigger as the editor doesn't trigger key inputs as Physical Key. Buttons work with them by default.

**3. Added a switch to the main panel hotkey**
Default hotkey is Ctrl+F6. There is no separate focusing hotkey needed as, unlike the bottom panel, this doesn't toggle out of view. Implementation is done with an offscreen Button that accesses the EditorInterface singleton to switch to the panel and then it is automatically focus it. The offscreen Button approach is also helpful here as once the terminal is out of view, its Controls don't process input, an offscreen Button added to the parent Control(should be Main Screen's VBoxContainer) can still receive the hotkey.

---------------------------------------------------------------------------------------------

All hotkeys can be changed in Editor Settings without needing a reload. Only a single InputKeyEvent is used per hotkey currently, since it might not be useful to have multiple keybinds for the same thing in the editor. The keybinds for corresponding panel won't do anything if you choose to not include it in the layout.

Lastly, one important default keybind to keep in mind for a more keyboard focused workflow is the Ctrl+Tab keybind, which is able to get you out of the terminal. Although this seems to have nothing to do with the terminal implementation, its default behavior of tabbing to previous Controls can get you out of the terminal without using the mouse. 

### TL;DR:
**Added:**
Alt+T -> Toggle bottom panel terminal
Ctrl+T -> Focus bottom panel terminal (further keypresses go to terminal)
Ctrl+F6 -> Switch to main screen terminal

**Built-in editor keybind to use alongside:**
Ctrl+Tab -> Unfocus whichever terminal is focused into 